### PR TITLE
fix: setting fee 0 for approval tx

### DIFF
--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -128,7 +128,7 @@ class User {
       this.ethPrivateKey,
       this.shieldContractAddress,
       value,
-      fee,
+      "0",
       this.web3Websocket.web3,
     );
     if (approvalReceipt === null) return null;


### PR DESCRIPTION
Closes #67.

**Resolution**

Approval tx does not require fees, which is potentially why the EVM was reverting all approval transactions.
