### PR TITLE
chore: error handling proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ npm run-script eg:export-commitments:ganache
 
 ### Error handling
 
-Today we are handling exceptions and raising this from the SDK using the `NightfallSdkError` class, which for now is a simple Error class. We might improve upon this in the future, but in the meantime, make sure to wrap any SDK calls within a `try/catch` statement.
+Today we are handling exceptions and raising these from the SDK using the `NightfallSdkError` class, which is a simple implementation of the Error class. We might improve this in the future, but in the meantime make sure to wrap all SDK calls within a `try/catch` block.
 
 ## Need help?
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,13 @@ To use the Nightfall SDK one must be aligned with the following requirements:
 
 This project uses Node.js 16.15.1. There is an `.nvmrc` file for those using [nvm](https://github.com/nvm-sh/nvm).
 
-### Nightfall client
+### Nightfall Client
 
 #### What is a Nightfall Client?
 
 The Nightfall Client is a key part of the architecture. It is the part which generates zero-knowledge proofs, stores zero-knowledge commitments and interacts with the contracts. The SDK uses Nightfall Client to interact with the Nightfall Protocol. To be able to use the SDK one must have a running instance of the Client.
 
-#### Setup a client
-
-##### Locally (Ganache)
+#### Setup a Client locally (Ganache)
 
 To use the SDK locally, set up and run the entire Nightfall project. The Client is part of this setup and by running the Project you are running the Client too.
 
@@ -49,7 +47,7 @@ cd nightfall_3
 ./start-nightfall -g
 ```
 
-###### Start the Proposer
+##### Start the Proposer
 
 ```bash
 cd nightfall_3/apps/proposer
@@ -57,7 +55,7 @@ npm install
 npm run start
 ```
 
-#### Goerli Testnet
+#### Setup a Client in testnet (Goerli)
 
 To use the SDK on a testnet you should only have a running Client, other parts of the infrastructure like the Proposer are provided.
 
@@ -82,48 +80,24 @@ BLOCKCHAIN_URL=your web3 url provider to access the blockchain
 ./start-client
 ```
 
-#### Ethereum Mainnet
-
-To use the SDK in production you should only have a running Client, other parts of the infrastructure like the Proposer are provided.
-
-```bash
-git clone https://github.com/EYBlockchain/nightfall_3.git
-cd nightfall_3/nightfall-client
-```
-
-##### Setup
-
-Rename `client-example.env` to `.client.env` and update the contents as following:
-
-```
-ETH_NETWORK=mainnet
-BLOCKCHAIN_URL=your web3 url provider to access the blockchain
-```
-
-##### Start client
-
-```bash
-./start-client
-```
-
-### SDK Setup
+## SDK Setup
 
 Now that you are finished with setting up Nightfall, let’s set up the SDK.
 
-#### Clone the repository:
+### Clone the repository
 
 ```bash
 git clone git@github.com:maticnetwork/nightfall-sdk.git
 cd nightfall-sdk
 ```
 
-#### Set Node.js version to 16.15.1:
+### Set Node.js version to 16.15.1
 
 ```
 nvm use
 ```
 
-#### Install requirements:
+### Install requirements
 
 ```
 npm install
@@ -165,13 +139,13 @@ Making a deposit, transfer or withdrawal means that a transaction is submitted t
 
 Upon each running of any of the scripts a new instance of the User class is created, if an existing Mnemonic isn’t specified in the .env file, a new Mnemonic is assigned to that specific user.
 
-##### Make a deposit
+#### Make a deposit
 
 ```
 npm run-script eg:deposit:ganache
 ```
 
-##### Make a transfer
+#### Make a transfer
 
 For making a transfer an already existing account with ERC20 balance is required. For testing purposes, this can be achieved by saving the mnemonic used for previous deposits and adding it to the .env file.
 
@@ -179,7 +153,7 @@ For making a transfer an already existing account with ERC20 balance is required
 npm run-script eg:transfer:ganache
 ```
 
-##### Make a withdrawal
+#### Make a withdrawal
 
 For making a withdrawal an already existing account with ERC20 balance is required. For testing purposes, this can be achieved by saving the mnemonic used for previous deposits and adding it to the .env file.
 
@@ -195,7 +169,7 @@ After initiating a withdrawal you will get a `withdrawTxHash`. To finalise a wit
 npm run-script eg:finalise-withdrawal:ganache
 ```
 
-##### Check L2 balances
+#### Check L2 balances
 
 Check your L2 balances.
 
@@ -203,7 +177,7 @@ Check your L2 balances.
 npm run-script eg:nf-balances:ganache
 ```
 
-##### Export commitments
+#### Export commitments
 
 For safety reasons, you can export your commitments and prevent losing them. While you have an exported copy of your Nightfall L2 commitments you can always import them, use them in Nightfall or withdraw them to Ethereum L1.
 
@@ -211,6 +185,12 @@ For safety reasons, you can export your commitments and prevent losing them. Whi
 npm run-script eg:export-commitments:ganache
 ```
 
-### Need help?
+## Using the SDK
+
+### Error handling
+
+Today we are handling exceptions and raising this from the SDK using the `NightfallSdkError` class, which for now is a simple Error class. We might improve upon this in the future, but in the meantime, make sure to wrap any SDK calls within a `try/catch` statement.
+
+## Need help?
 
 If you have any questions or need some help, join the [Polygon Nightfall discord server](https://discord.com/invite/pZkC3JV2bR).

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -10,8 +10,6 @@ const logger = parentLogger.child({
   name: path.relative(process.cwd(), __filename),
 });
 
-const ERR_REQ_GET_CONTRACT_ADDRESS =
-  "Client get request at contract-address failed";
 /**
  * Creates a new Client
  *
@@ -65,10 +63,11 @@ class Client {
   /**
    * Make GET request to get the address for a given contract name
    *
+   * @async
    * @method getContractAddress
    * @param {string} contractName The name of the contract for which we need the address
-   * @throws {NightfallSdkError} ERR_REQ_GET_CONTRACT_ADDRESS
-   * @return {Promise<null | string>} Address if request is successful, else null
+   * @throws {NightfallSdkError} Bad response
+   * @return {Promise<string>} Eth contract address
    */
   async getContractAddress(contractName: string): Promise<string> {
     const endpoint = `contract-address/${contractName}`;
@@ -83,7 +82,7 @@ class Client {
       );
     } catch (err) {
       logger.child({ contractName }).error(err);
-      throw new NightfallSdkError(ERR_REQ_GET_CONTRACT_ADDRESS);
+      throw new NightfallSdkError(err);
     }
     return res.data.address;
   }

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -10,6 +10,14 @@ const logger = parentLogger.child({
   name: path.relative(process.cwd(), __filename),
 });
 
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    logger.error(error);
+    throw new NightfallSdkError(error.message);
+  },
+);
+
 /**
  * Creates a new Client
  *
@@ -73,17 +81,12 @@ class Client {
     const endpoint = `contract-address/${contractName}`;
     logger.debug({ endpoint }, "Calling client at");
 
-    let res: AxiosResponse;
-    try {
-      res = await axios.get(`${this.apiUrl}/${endpoint}`);
-      logger.info(
-        { status: res.status, data: res.data },
-        `${endpoint} responded`,
-      );
-    } catch (err) {
-      logger.child({ contractName }).error(err);
-      throw new NightfallSdkError(err);
-    }
+    const res = await axios.get(`${this.apiUrl}/${endpoint}`);
+    logger.info(
+      { status: res.status, data: res.data },
+      `${endpoint} responded`,
+    );
+
     return res.data.address;
   }
 

--- a/libs/ethereum/keys.ts
+++ b/libs/ethereum/keys.ts
@@ -1,6 +1,7 @@
 import type Web3 from "web3";
 import path from "path";
 import { parentLogger } from "../utils";
+import { NightfallSdkError } from "../utils/error";
 
 const logger = parentLogger.child({
   name: path.relative(process.cwd(), __filename),
@@ -12,12 +13,10 @@ const logger = parentLogger.child({
  * @function getEthAccountAddress
  * @param {string} ethereumPrivateKey
  * @param {Web3} web3
- * @returns {null|string} address <string> if the private key is valid, else return null
+ * @throws {NightfallSdkError} Error while validating eth private key
+ * @returns {string} Eth account address
  */
-export function getEthAccountAddress(
-  ethereumPrivateKey: string,
-  web3: Web3,
-): null | string {
+export function getEthAccountAddress(ethereumPrivateKey: string, web3: Web3): string {
   logger.debug("getEthAccountAddress");
   let ethAccount;
   try {
@@ -29,10 +28,10 @@ export function getEthAccountAddress(
     logger
       .child({ ethereumPrivateKey })
       .error(err, "Error while validating eth private key");
-    return null;
+    throw new NightfallSdkError(err);
   }
   const address = ethAccount.address;
-  logger.info({ address }, "Eth address is");
+  logger.info({ address }, "Eth account address is");
 
   return address;
 }

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -61,7 +61,6 @@ class UserFactory {
 
     // Get the Eth account address from private key if it's a valid key
     const ethAddress = getEthAccountAddress(ethPrivateKey, web3Websocket.web3);
-    if (!ethAddress) throw new Error("Unable to get an Eth address");
 
     // Create a set of Zero-knowledge proof keys from a valid mnemonic
     // or from a new mnemonic if none was provided,

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -58,8 +58,6 @@ class UserFactory {
     const shieldContractAddress = await client.getContractAddress(
       CONTRACT_SHIELD,
     );
-    if (!shieldContractAddress)
-      throw new Error("Unable to get Shield contract address");
 
     // Get the Eth account address from private key if it's a valid key
     const ethAddress = getEthAccountAddress(ethPrivateKey, web3Websocket.web3);

--- a/libs/utils/error.ts
+++ b/libs/utils/error.ts
@@ -1,0 +1,7 @@
+// TODO review export
+export class NightfallSdkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NightfallSdkError";
+  }
+}


### PR DESCRIPTION
Resolves #64 

### Changes

Created `NightfallSdkError` class to pass custom messages, like `ERR_REQ_GET_CONTRACT_ADDRESS` (the idea would be to have these messages on dedicated files).

CHECK: We throw the error returned by the request, and we "leave it unhandled", so that SDK calls always need to be wrapped within try/catch (?), hence the changes in libs/user/user.ts

### How to test

You can  test by passing a different string to `getContractAddress`: instead of `CONTRACT_SHIELD`, pass "pepe". The try running example deposit with `npm run eg:deposit:ganache`.

### Outcome

Error
```
NightfallSdkError: Client get request at contract-address failed
    at Client.getContractAddress (/home/bea/Dev/Polygon/nightfall-sdk/libs/client/client.ts:85:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Function.create (/home/bea/Dev/Polygon/nightfall-sdk/libs/user/user.ts:58:35)
    at async main (/home/bea/Dev/Polygon/nightfall-sdk/examples/txDeposit.ts:9:12)
```

Error log

![image](https://user-images.githubusercontent.com/7704645/183599467-6c5348e8-935b-4798-8c4e-37e7cd69e32c.png)

What do you think? :thinking: :pray: 
