### PR TITLE
fix: transaction fees

### DIFF
--- a/examples/exportCommitments.ts
+++ b/examples/exportCommitments.ts
@@ -23,6 +23,7 @@ const main = async () => {
     process.exit(1);
   } finally {
     user.close();
+    console.log("Bye bye");
   }
 };
 

--- a/examples/txTransfer.ts
+++ b/examples/txTransfer.ts
@@ -44,7 +44,7 @@ const main = async () => {
   } finally {
     userSender.close();
     userRecipient.close();
-    console.log("Closing tranfer operation!");
+    console.log("Bye bye");
   }
 };
 

--- a/libs/transactions/helpers/submit.ts
+++ b/libs/transactions/helpers/submit.ts
@@ -58,7 +58,9 @@ export async function submitTransaction(
     from: senderAddress,
     to: recipientAddress,
     data: unsignedTx,
+    value: fee,
     gas,
+    gasPrice,
   };
   logger.debug({ tx }, "Sign tx...");
   const signedTx = await web3.eth.accounts.signTransaction(

--- a/libs/transactions/transfer.ts
+++ b/libs/transactions/transfer.ts
@@ -72,7 +72,6 @@ export async function createAndSubmitTransfer(
         shieldContractAddress,
         unsignedTx,
         web3,
-        fee,
       );
     } catch (err) {
       logger.child({ unsignedTx }).error(err);

--- a/libs/transactions/withdrawal.ts
+++ b/libs/transactions/withdrawal.ts
@@ -49,7 +49,6 @@ export async function createAndSubmitWithdrawal(
         shieldContractAddress,
         unsignedTx,
         web3,
-        fee,
       );
     } catch (err) {
       logger.child({ unsignedTx }).error(err);

--- a/libs/user/constants.ts
+++ b/libs/user/constants.ts
@@ -1,2 +1,3 @@
 export const CONTRACT_SHIELD = "Shield";
-export const TX_FEE_GWEI_DEFAULT = "12";
+export const TX_FEE_ETH_GWEI_DEFAULT = "12";
+export const TX_FEE_MATIC_GWEI_DEFAULT = "12";

--- a/libs/user/constants.ts
+++ b/libs/user/constants.ts
@@ -1,3 +1,3 @@
 export const CONTRACT_SHIELD = "Shield";
-export const TX_FEE_ETH_GWEI_DEFAULT = "12";
-export const TX_FEE_MATIC_GWEI_DEFAULT = "12";
+export const TX_FEE_ETH_WEI_DEFAULT = "10";
+export const TX_FEE_MATIC_WEI_DEFAULT = "10";

--- a/libs/user/types.ts
+++ b/libs/user/types.ts
@@ -24,7 +24,7 @@ export interface UserMakeTransaction {
   tokenAddress: string;
   tokenStandard: string;
   value: string;
-  feeGwei?: string;
+  feeWei?: string;
 }
 
 export type UserMakeDeposit = UserMakeTransaction;

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -1,5 +1,9 @@
 import path from "path";
-import { CONTRACT_SHIELD, TX_FEE_GWEI_DEFAULT } from "./constants";
+import {
+  CONTRACT_SHIELD,
+  TX_FEE_ETH_GWEI_DEFAULT,
+  TX_FEE_MATIC_GWEI_DEFAULT,
+} from "./constants";
 import {
   UserFactoryCreate,
   UserConstructor,
@@ -124,7 +128,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_GWEI_DEFAULT;
+    const feeGwei = options.feeGwei?.trim() || TX_FEE_ETH_GWEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
 
@@ -190,7 +194,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_GWEI_DEFAULT;
+    const feeGwei = options.feeGwei?.trim() || TX_FEE_MATIC_GWEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
     const nightfallRecipientAddress = options.nightfallRecipientAddress.trim();
@@ -241,7 +245,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_GWEI_DEFAULT;
+    const feeGwei = options.feeGwei?.trim() || TX_FEE_MATIC_GWEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
     const ethRecipientAddress = options.ethRecipientAddress.trim();

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -1,8 +1,8 @@
 import path from "path";
 import {
   CONTRACT_SHIELD,
-  TX_FEE_ETH_GWEI_DEFAULT,
-  TX_FEE_MATIC_GWEI_DEFAULT,
+  TX_FEE_ETH_WEI_DEFAULT,
+  TX_FEE_MATIC_WEI_DEFAULT,
 } from "./constants";
 import {
   UserFactoryCreate,
@@ -138,7 +138,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_ETH_GWEI_DEFAULT;
+    const feeWei = options.feeWei?.trim() || TX_FEE_ETH_WEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
 
@@ -154,8 +154,7 @@ class User {
 
     // Convert value and fee to wei
     const valueWei = stringValueToWei(value, this.token.decimals);
-    const feeWei = feeGwei + "000000000";
-    logger.info({ valueWei, feeWei }, "Value and fee in wei");
+    logger.info({ valueWei, feeWei }, "Value and fee in Wei");
 
     // Deposit tx might need approval
     const approvalReceipt = await createAndSubmitApproval(
@@ -204,7 +203,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_MATIC_GWEI_DEFAULT;
+    const feeWei = options.feeWei?.trim() || TX_FEE_MATIC_WEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
     const nightfallRecipientAddress = options.nightfallRecipientAddress.trim();
@@ -222,8 +221,7 @@ class User {
 
     // Convert value and fee to wei
     const valueWei = stringValueToWei(value, this.token.decimals);
-    const feeWei = feeGwei + "000000000";
-    logger.info({ valueWei, feeWei }, "Value and fee in wei");
+    logger.info({ valueWei, feeWei }, "Value and fee in Wei");
 
     const transferReceipts = await createAndSubmitTransfer(
       this.token,
@@ -255,7 +253,7 @@ class User {
 
     // Format options
     const value = options.value.trim();
-    const feeGwei = options.feeGwei?.trim() || TX_FEE_MATIC_GWEI_DEFAULT;
+    const feeWei = options.feeWei?.trim() || TX_FEE_MATIC_WEI_DEFAULT;
     const tokenAddress = options.tokenAddress.trim();
     const tokenStandard = options.tokenStandard.trim().toUpperCase();
     const ethRecipientAddress = options.ethRecipientAddress.trim();
@@ -273,8 +271,7 @@ class User {
 
     // Convert value and fee to wei
     const valueWei = stringValueToWei(value, this.token.decimals);
-    const feeWei = feeGwei + "000000000";
-    logger.info({ valueWei, feeWei }, "Value and fee in wei");
+    logger.info({ valueWei, feeWei }, "Value and fee in Wei");
 
     // Withdrawal
     const withdrawalReceipts = await createAndSubmitWithdrawal(

--- a/libs/user/validations.ts
+++ b/libs/user/validations.ts
@@ -31,7 +31,7 @@ export const makeDepositOptions = Joi.object({
     .valid(...Object.keys(TOKEN_STANDARDS))
     .required(),
   value: Joi.string().required(),
-  feeGwei: Joi.string(),
+  feeWei: Joi.string(),
 });
 
 export const makeTransferOptions = Joi.object({
@@ -46,7 +46,7 @@ export const makeTransferOptions = Joi.object({
     .required(),
   value: Joi.string().required(),
   nightfallRecipientAddress: Joi.string().trim().required(), // ISSUE #76
-  feeGwei: Joi.string(),
+  feeWei: Joi.string(),
   isOffChain: Joi.boolean(),
 });
 
@@ -65,7 +65,7 @@ export const makeWithdrawalOptions = Joi.object({
     .trim()
     .custom(isChecksum, "custom validation")
     .required(),
-  feeGwei: Joi.string(),
+  feeWei: Joi.string(),
   isOffChain: Joi.boolean(),
 });
 


### PR DESCRIPTION
Resolves #82 

This PR restores compatibility with Nightfall where fees have evolved to introduce proposer payments - _coming soon_.
NOTE: **For the SDK to work [nightfall_3 PR #873](https://github.com/EYBlockchain/nightfall_3/pull/873) needs to be merged first**.

In summary:

- When making deposits, fees are to be paid in Ether and are passed in the Eth tx as `tx.value`
- When making transfers and withdrawals, fees are to be paid in MATIC (user will need MATIC balance in L2), and these are included as part of the L2 transaction

This PR also simplifies fees, to be taken and managed in `Wei` directly. This might change once we better define our goals.