### PR TITLE
fix: token approval in the browser

### DIFF
--- a/examples/webApp/src/components/HelloWorld.vue
+++ b/examples/webApp/src/components/HelloWorld.vue
@@ -24,10 +24,11 @@ export default class HelloWorld extends Vue {
   user: null | any = null;
   nightfallBalances: null | any = null;
 
-  tokenContractAddress = "0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae";
+  tokenContractAddress = "0xa8473bEF03cBE50229a39718CBDC1fdee2F26b1a";
   tokenErcStandard = "ERC20";
-  txValue = "0.0001";
+  txValue = "1";
   txOffChain = false;
+  // Review
   recipientNightfallAddress =
     "0xacf25b7a8894165b80aa5c59b07218e9a918b745565938b0b7d1f11ff0f0ab3a";
   recipientEthAddress = "0x9C8B2276D490141Ae1440Da660E470E7C0349C63";

--- a/libs/transactions/deposit.ts
+++ b/libs/transactions/deposit.ts
@@ -52,7 +52,6 @@ export async function createAndSubmitDeposit(
     tokenId,
     fee,
   );
-
   const txReceiptL2 = resData.transaction;
   const unsignedTx = resData.txDataToSign;
   logger.debug({ unsignedTx }, "Deposit tx, unsigned");


### PR DESCRIPTION
Closes #119 

**FYI This will only work on Ganache [1]**

What you need to test:

- Script deposit for ERC20 still works (when approval is needed [2] and when it's not)
- Script deposit for ERC721 still works (when approval is needed and when it's not)
- Browser approval (web-app is only ERC20 for now) works

[1] Configure MetaMask to work with localhost and import nightfall_3 users and token addresses
[2] Bear in mind approval only happens when you deposit for the first time with an account. So keep an eye on the logs and clean the volumes if needed, etc.

To run the front-end app, from /nightfall-sdk:

```bash
npm run eg:web-app
```



