### PR TITLE
refactor: updated deposit tx according to l2 tokenisation feature

### DIFF
--- a/__tests__/unit/transactions/transactions.test.ts
+++ b/__tests__/unit/transactions/transactions.test.ts
@@ -10,6 +10,9 @@ import { depositReceipts } from "../../../__mocks__/mockTxDepositReceipts";
 import { transferReceipts } from "../../../__mocks__/mockTxTransferReceipts";
 import { withdrawalReceipts } from "../../../__mocks__/mockTxWithdrawalReceipts";
 import { txReceipt } from "../../../__mocks__/mockTxWithdrawalFinaliseReceipt";
+import type { NightfallZkpKeys } from "../../../libs/nightfall/types";
+import type Web3 from "web3";
+import type { Client } from "../../../libs/client";
 
 jest.mock("../../../libs/transactions/helpers/submit");
 
@@ -30,7 +33,8 @@ describe("Transactions", () => {
 
   describe("Deposit", () => {
     const value = "70000000000000000";
-    const fee = "10";
+    const feeL1 = "10";
+    const feeL2 = "0";
     const tokenId = "0x00";
     const unsignedTx =
       "0x9ae2b6be00000000000000000000000000000000000000000000000000f...";
@@ -49,15 +53,14 @@ describe("Transactions", () => {
             token,
             ownerEthAddress,
             ownerEthPrivateKey,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            ownerZkpKeys,
+            ownerZkpKeys as unknown as NightfallZkpKeys,
             shieldContractAddress,
-            web3,
-            mockedClient,
+            web3 as unknown as Web3,
+            mockedClient as unknown as Client,
             value,
             tokenId,
-            fee,
+            feeL1,
+            feeL2,
           ),
       ).rejects.toThrow(NightfallSdkError);
       expect(mockedClient.deposit).toHaveBeenCalledTimes(1);
@@ -77,15 +80,14 @@ describe("Transactions", () => {
         token,
         ownerEthAddress,
         ownerEthPrivateKey,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        ownerZkpKeys,
+        ownerZkpKeys as unknown as NightfallZkpKeys,
         shieldContractAddress,
-        web3,
-        mockedClient,
+        web3 as unknown as Web3,
+        mockedClient as unknown as Client,
         value,
         tokenId,
-        fee,
+        feeL1,
+        feeL2,
       );
 
       // Assert
@@ -94,7 +96,7 @@ describe("Transactions", () => {
         ownerZkpKeys,
         value,
         tokenId,
-        fee,
+        feeL2,
       );
       expect(submitTransaction).toHaveBeenCalledWith(
         ownerEthAddress,
@@ -102,7 +104,7 @@ describe("Transactions", () => {
         shieldContractAddress,
         unsignedTx,
         web3,
-        fee,
+        feeL1,
       );
       expect(txReceipts).toStrictEqual({ txReceipt, txReceiptL2 });
     });
@@ -136,12 +138,10 @@ describe("Transactions", () => {
             token,
             ownerEthAddress,
             ownerEthPrivateKey,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            ownerZkpKeys,
+            ownerZkpKeys as unknown as NightfallZkpKeys,
             shieldContractAddress,
-            web3,
-            mockedClient,
+            web3 as unknown as Web3,
+            mockedClient as unknown as Client,
             value,
             tokenId,
             fee,
@@ -163,12 +163,10 @@ describe("Transactions", () => {
         token,
         ownerEthAddress,
         ownerEthPrivateKey,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        ownerZkpKeys,
+        ownerZkpKeys as unknown as NightfallZkpKeys,
         shieldContractAddress,
-        web3,
-        mockedClient,
+        web3 as unknown as Web3,
+        mockedClient as unknown as Client,
         value,
         tokenId,
         fee,
@@ -215,12 +213,10 @@ describe("Transactions", () => {
             token,
             ownerEthAddress,
             ownerEthPrivateKey,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            ownerZkpKeys,
+            ownerZkpKeys as unknown as NightfallZkpKeys,
             shieldContractAddress,
-            web3,
-            mockedClient,
+            web3 as unknown as Web3,
+            mockedClient as unknown as Client,
             value,
             tokenId,
             fee,
@@ -242,12 +238,10 @@ describe("Transactions", () => {
         token,
         ownerEthAddress,
         ownerEthPrivateKey,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        ownerZkpKeys,
+        ownerZkpKeys as unknown as NightfallZkpKeys,
         shieldContractAddress,
-        web3,
-        mockedClient,
+        web3 as unknown as Web3,
+        mockedClient as unknown as Client,
         value,
         tokenId,
         fee,
@@ -289,10 +283,8 @@ describe("Transactions", () => {
             ownerEthAddress,
             ownerEthPrivateKey,
             shieldContractAddress,
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            web3,
-            mockedClient,
+            web3 as unknown as Web3,
+            mockedClient as unknown as Client,
             withdrawTxHashL2,
           ),
       ).rejects.toThrow(NightfallSdkError);

--- a/examples/scripts/txDeposit.ts
+++ b/examples/scripts/txDeposit.ts
@@ -29,6 +29,7 @@ const main = async () => {
     const txReceipts = await user.makeDeposit({
       tokenContractAddress: config.tokenContractAddress,
       value: config.value,
+      // isFeePaidInL2: true,
       // tokenId: config.tokenId,
     });
     console.log("Transaction receipts", txReceipts);

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -147,7 +147,7 @@ class Client {
    * @param {NightfallZkpKeys} ownerZkpKeys Sender's set of Zero-knowledge proof keys
    * @param {string} value The amount in Wei of the token to be deposited
    * @param {string} tokenId The tokenId of the token to be deposited
-   * @param {string} fee The amount in Wei to pay a proposer for the tx
+   * @param {string} fee Proposer payment for the tx in L2
    * @throws {NightfallSdkError} Bad response
    * @returns {Promise<TransactionResponseData>}
    */

--- a/libs/transactions/deposit.ts
+++ b/libs/transactions/deposit.ts
@@ -27,7 +27,8 @@ const logger = parentLogger.child({
  * @param {Client} client An instance of Client to interact with the API
  * @param {string} value The amount in Wei of the token to be deposited
  * @param {string} tokenId The tokenId of an erc721
- * @param {string} fee The amount in Wei to pay a proposer for the tx
+ * @param {string} feeL1 Proposer payment for the tx in L1
+ * @param {string} feeL2 Proposer payment for the tx in L2
  * @throws {NightfallSdkError} Error while broadcasting tx
  * @returns {Promise<OnChainTransactionReceipts>}
  */
@@ -41,7 +42,8 @@ export async function createAndSubmitDeposit(
   client: Client,
   value: string,
   tokenId: string,
-  fee: string,
+  feeL1: string,
+  feeL2: string,
 ): Promise<OnChainTransactionReceipts> {
   logger.debug("createAndSubmitDeposit");
 
@@ -50,7 +52,7 @@ export async function createAndSubmitDeposit(
     ownerZkpKeys,
     value,
     tokenId,
-    fee,
+    feeL2,
   );
   const txReceiptL2 = resData.transaction;
   const unsignedTx = resData.txDataToSign;
@@ -64,7 +66,7 @@ export async function createAndSubmitDeposit(
       shieldContractAddress,
       unsignedTx,
       web3,
-      fee,
+      feeL1,
     );
   } catch (err) {
     logger.child({ resData }).error(err, "Error when submitting transaction");

--- a/libs/transactions/helpers/submit.ts
+++ b/libs/transactions/helpers/submit.ts
@@ -26,7 +26,7 @@ const GAS_PRICE_MULTIPLIER = Number(process.env.GAS_PRICE_MULTIPLIER) || 2;
  * @param {string} recipientEthAddress Eth address receiving the contents of the tx
  * @param {string} unsignedTx The contents of the tx (sent in data)
  * @param {Web3} web3 web3js instance
- * @param {string} fee The amount in Wei to pay a proposer for the tx
+ * @param {string} value Proposer payment for the tx in L1
  * @returns {Promise<TransactionReceipt>}
  */
 export async function submitTransaction(
@@ -35,10 +35,10 @@ export async function submitTransaction(
   recipientEthAddress: string,
   unsignedTx: string,
   web3: Web3,
-  fee = "0",
+  value = "0",
 ): Promise<TransactionReceipt> {
   logger.debug(
-    { senderEthAddress, recipientEthAddress, unsignedTx, fee },
+    { senderEthAddress, recipientEthAddress, unsignedTx, value },
     "submitTransaction",
   );
 
@@ -55,7 +55,7 @@ export async function submitTransaction(
     from: senderEthAddress,
     to: recipientEthAddress,
     data: unsignedTx,
-    value: fee,
+    value,
     gas,
     gasPrice,
   };

--- a/libs/user/types.ts
+++ b/libs/user/types.ts
@@ -27,7 +27,9 @@ export interface UserMakeTransaction {
   feeWei?: string;
 }
 
-export type UserMakeDeposit = UserMakeTransaction;
+export interface UserMakeDeposit extends UserMakeTransaction {
+  isFeePaidInL2?: boolean;
+}
 
 export interface UserMakeTransfer extends UserMakeTransaction {
   recipientNightfallAddress: string;

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -219,6 +219,7 @@ class User {
    * @param {string} [options.value]
    * @param {string} [options.tokenId]
    * @param {string} [options.feeWei]
+   * @param {boolean} [options.isFeePaidInL2]
    * @returns {Promise<OnChainTransactionReceipts>}
    */
   async makeDeposit(
@@ -231,7 +232,7 @@ class User {
     isInputValid(error);
     logger.debug({ joiValue }, "makeDeposit formatted parameters");
 
-    const { tokenContractAddress, value, feeWei } = joiValue;
+    const { tokenContractAddress, value, feeWei, isFeePaidInL2 } = joiValue;
     let { tokenId } = joiValue;
 
     // Determine ERC standard, set value/tokenId defaults,
@@ -244,6 +245,15 @@ class User {
     );
     const { token, valueWei } = result;
     tokenId = result.tokenId;
+
+    // Set fees
+    let feeL1,
+      feeL2 = "0";
+    if (isFeePaidInL2) {
+      feeL2 = feeWei;
+    } else {
+      feeL1 = feeWei;
+    }
 
     // Approval
     const approvalReceipt = await createAndSubmitApproval(
@@ -268,7 +278,8 @@ class User {
       this.client,
       valueWei,
       tokenId,
-      feeWei,
+      feeL1,
+      feeL2,
     );
     logger.info({ depositReceipts }, "Deposit completed!");
 

--- a/libs/user/validations.ts
+++ b/libs/user/validations.ts
@@ -20,7 +20,9 @@ const makeTransaction = Joi.object({
   feeWei: Joi.string().default(TX_FEE_ETH_WEI_DEFAULT),
 }).or("value", "tokenId"); // these cannot have default
 
-export const makeDepositOptions = makeTransaction;
+export const makeDepositOptions = makeTransaction.append({
+  isFeePaidInL2: Joi.boolean().default(false),
+});
 
 export const makeTransferOptions = makeTransaction.append({
   feeWei: Joi.string().default(TX_FEE_MATIC_WEI_DEFAULT),


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Deposit transaction has been updated so that users can specify via `isFeePaidInL2` if they want to pay the proposer fee in L1 or L2. This is needed since the current implementation is probably a bit behind - in terms of fees management, which is causing deposits to fail.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

Start nightfall (with ganache). Run the deposit script with

```
npm run eg:ganache:deposit
```

Also note that ERC addresses may have changed

```
APP_TOKEN_ERC20=0xe721f2d97c58b1d1ccd0c80b88256a152d27f0fe
APP_TOKEN_ERC721=0xda0107986bc43e207d0bb4d9c9a22d35e09db425
APP_TOKEN_ERC1155=0x59ee10cf73e3cfcde03c8813f2ad57eac2248248
```

## Any other comments?

N/a