### PR TITLE
fix: fees only paid in L2

### DIFF
--- a/__tests__/unit/client/client.test.ts
+++ b/__tests__/unit/client/client.test.ts
@@ -150,8 +150,7 @@ describe("Client", () => {
         tokenType: token.ercStandard,
         tokenId: "0x00",
         value,
-        compressedZkpPublicKey: zkpKeys.compressedZkpPublicKey,
-        nullifierKey: zkpKeys.nullifierKey,
+        rootKey: zkpKeys.rootKey,
         fee,
       });
       expect(result).toBe(data);

--- a/__tests__/unit/transactions/transactions.test.ts
+++ b/__tests__/unit/transactions/transactions.test.ts
@@ -33,8 +33,7 @@ describe("Transactions", () => {
 
   describe("Deposit", () => {
     const value = "70000000000000000";
-    const feeL1 = "10";
-    const feeL2 = "0";
+    const fee = "10";
     const tokenId = "0x00";
     const unsignedTx =
       "0x9ae2b6be00000000000000000000000000000000000000000000000000f...";
@@ -59,8 +58,7 @@ describe("Transactions", () => {
             mockedClient as unknown as Client,
             value,
             tokenId,
-            feeL1,
-            feeL2,
+            fee,
           ),
       ).rejects.toThrow(NightfallSdkError);
       expect(mockedClient.deposit).toHaveBeenCalledTimes(1);
@@ -86,8 +84,7 @@ describe("Transactions", () => {
         mockedClient as unknown as Client,
         value,
         tokenId,
-        feeL1,
-        feeL2,
+        fee,
       );
 
       // Assert
@@ -96,7 +93,7 @@ describe("Transactions", () => {
         ownerZkpKeys,
         value,
         tokenId,
-        feeL2,
+        fee,
       );
       expect(submitTransaction).toHaveBeenCalledWith(
         ownerEthAddress,
@@ -104,7 +101,6 @@ describe("Transactions", () => {
         shieldContractAddress,
         unsignedTx,
         web3,
-        feeL1,
       );
       expect(txReceipts).toStrictEqual({ txReceipt, txReceiptL2 });
     });

--- a/examples/scripts/txDeposit.ts
+++ b/examples/scripts/txDeposit.ts
@@ -29,7 +29,6 @@ const main = async () => {
     const txReceipts = await user.makeDeposit({
       tokenContractAddress: config.tokenContractAddress,
       value: config.value,
-      // isFeePaidInL2: true,
       // tokenId: config.tokenId,
     });
     console.log("Transaction receipts", txReceipts);

--- a/libs/client/client.ts
+++ b/libs/client/client.ts
@@ -158,10 +158,9 @@ class Client {
     const res = await axios.post(`${this.apiUrl}/${endpoint}`, {
       ercAddress: token.contractAddress,
       tokenType: token.ercStandard,
+      rootKey: ownerZkpKeys.rootKey,
       value,
       tokenId,
-      compressedZkpPublicKey: ownerZkpKeys.compressedZkpPublicKey,
-      nullifierKey: ownerZkpKeys.nullifierKey,
       fee,
     });
     logger.info(
@@ -198,12 +197,12 @@ class Client {
     logger.debug({ endpoint }, "Calling client at");
 
     const res = await axios.post(`${this.apiUrl}/${endpoint}`, {
-      offchain: isOffChain,
       ercAddress: token.contractAddress,
-      tokenId,
       rootKey: ownerZkpKeys.rootKey,
       recipientData: recipientNightfallData,
+      tokenId,
       fee,
+      offchain: isOffChain,
     });
     if (res.data.error && res.data.error === "No suitable commitments") {
       logger.error(res, "No suitable commitments were found");

--- a/libs/transactions/deposit.ts
+++ b/libs/transactions/deposit.ts
@@ -20,8 +20,7 @@ import type { OnChainTransactionReceipts } from "./types";
  * @param {Client} client An instance of Client to interact with the API
  * @param {string} value The amount in Wei of the token to be deposited
  * @param {string} tokenId The tokenId of an erc721
- * @param {string} feeL1 Proposer payment for the tx in L1
- * @param {string} feeL2 Proposer payment for the tx in L2
+ * @param {string} fee Proposer payment for the tx in L2 [Wei]
  * @throws {NightfallSdkError} Error while broadcasting tx
  * @returns {Promise<OnChainTransactionReceipts>}
  */
@@ -35,8 +34,7 @@ export async function createAndSubmitDeposit(
   client: Client,
   value: string,
   tokenId: string,
-  feeL1: string,
-  feeL2: string,
+  fee: string,
 ): Promise<OnChainTransactionReceipts> {
   logger.debug("createAndSubmitDeposit");
 
@@ -45,7 +43,7 @@ export async function createAndSubmitDeposit(
     ownerZkpKeys,
     value,
     tokenId,
-    feeL2,
+    fee,
   );
   const txReceiptL2 = resData.transaction;
   const unsignedTx = resData.txDataToSign;
@@ -59,7 +57,6 @@ export async function createAndSubmitDeposit(
       shieldContractAddress,
       unsignedTx,
       web3,
-      feeL1,
     );
   } catch (err) {
     logger.child({ resData }).error(err, "Error when submitting transaction");

--- a/libs/transactions/helpers/submit.ts
+++ b/libs/transactions/helpers/submit.ts
@@ -2,15 +2,10 @@ import type Web3 from "web3";
 import { logger } from "../../utils";
 import type { TransactionReceipt } from "web3-core";
 
-const GAS = globalThis.process?.env.GAS ?? 4000000;
-const GAS_PRICE = globalThis.process?.env.GAS_PRICE ?? 10000000000;
-// const GAS_ESTIMATE_ENDPOINT =
-//   globalThis.process?.env.GAS_ESTIMATE_ENDPOINT ??
-//   "https://vqxy02tr5e.execute-api.us-east-2.amazonaws.com/production/estimateGas";
-
-const GAS_MULTIPLIER = Number(globalThis.process?.env.GAS_MULTIPLIER) ?? 2;
-const GAS_PRICE_MULTIPLIER =
-  Number(globalThis.process?.env.GAS_PRICE_MULTIPLIER) ?? 2;
+const GAS = 4000000;
+const GAS_PRICE = 10000000000;
+const GAS_MULTIPLIER = 2;
+const GAS_PRICE_MULTIPLIER = 2;
 
 /**
  * Create, sign and broadcast an Ethereum transaction (tx) to the network

--- a/libs/user/constants.ts
+++ b/libs/user/constants.ts
@@ -1,5 +1,4 @@
 export const CONTRACT_SHIELD = "Shield";
-export const TX_FEE_ETH_WEI_DEFAULT = "10";
-export const TX_FEE_MATIC_WEI_DEFAULT = "10";
+export const TX_FEE_WEI_DEFAULT = "10";
 export const TX_VALUE_DEFAULT = "0";
 export const TX_TOKEN_ID_DEFAULT = "0x00";

--- a/libs/user/types.ts
+++ b/libs/user/types.ts
@@ -27,9 +27,7 @@ export interface UserMakeTransaction {
   feeWei?: string;
 }
 
-export interface UserMakeDeposit extends UserMakeTransaction {
-  isFeePaidInL2?: boolean;
-}
+export type UserMakeDeposit = UserMakeTransaction;
 
 export interface UserMakeTransfer extends UserMakeTransaction {
   recipientNightfallAddress: string;

--- a/libs/user/user.ts
+++ b/libs/user/user.ts
@@ -226,7 +226,7 @@ class User {
     isInputValid(error);
     logger.debug({ joiValue }, "makeDeposit formatted parameters");
 
-    const { tokenContractAddress, value, feeWei, isFeePaidInL2 } = joiValue;
+    const { tokenContractAddress, value, feeWei } = joiValue;
     let { tokenId } = joiValue;
 
     // Determine ERC standard, set value/tokenId defaults,
@@ -239,15 +239,6 @@ class User {
     );
     const { token, valueWei } = result;
     tokenId = result.tokenId;
-
-    // Set fees
-    let feeL1,
-      feeL2 = "0";
-    if (isFeePaidInL2) {
-      feeL2 = feeWei;
-    } else {
-      feeL1 = feeWei;
-    }
 
     // Approval
     const approvalReceipt = await createAndSubmitApproval(
@@ -272,8 +263,7 @@ class User {
       this.client,
       valueWei,
       tokenId,
-      feeL1,
-      feeL2,
+      feeWei,
     );
     logger.info({ depositReceipts }, "Deposit completed!");
 

--- a/libs/user/validations.ts
+++ b/libs/user/validations.ts
@@ -1,6 +1,6 @@
 import Joi, { ValidationError } from "joi";
 import { NightfallSdkError } from "../utils/error";
-import { TX_FEE_ETH_WEI_DEFAULT, TX_FEE_MATIC_WEI_DEFAULT } from "./constants";
+import { TX_FEE_WEI_DEFAULT } from "./constants";
 
 // See https://joi.dev/tester/
 
@@ -17,21 +17,17 @@ const makeTransaction = Joi.object({
   tokenErcStandard: Joi.string(), // keep it for a while for compatibility
   value: Joi.string(),
   tokenId: Joi.string(),
-  feeWei: Joi.string().default(TX_FEE_ETH_WEI_DEFAULT),
+  feeWei: Joi.string().default(TX_FEE_WEI_DEFAULT),
 }).or("value", "tokenId"); // these cannot have default
 
-export const makeDepositOptions = makeTransaction.append({
-  isFeePaidInL2: Joi.boolean().default(false),
-});
+export const makeDepositOptions = makeTransaction;
 
 export const makeTransferOptions = makeTransaction.append({
-  feeWei: Joi.string().default(TX_FEE_MATIC_WEI_DEFAULT),
   recipientNightfallAddress: Joi.string().trim().required(), // ISSUE #76
   isOffChain: Joi.boolean().default(false),
 });
 
 export const makeWithdrawalOptions = makeTransaction.append({
-  feeWei: Joi.string().default(TX_FEE_MATIC_WEI_DEFAULT),
   recipientEthAddress: Joi.string().trim().required(),
   isOffChain: Joi.boolean().default(false),
 });


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

Change needed after merging [1272: Fees are only paid in L2](https://github.com/EYBlockchain/nightfall_3/pull/1272) - nightfall_3.

## Does this close any currently open issues?

No

## What commands can I run to test the change? 

```
npm run eg:ganache:deposit
```

## Any other comments?

New token addresses

```
APP_TOKEN_ERC20=0x7F68ba0dB1D62fB166758Fe5Ef10853537F8DFc5
APP_TOKEN_ERC721=0x60234EB1380175818ca2c22Fa64Eee04e174fbE2
APP_TOKEN_ERC1155=0xe28C7F9D1a79677F2C48BdcD678197bDa40b883e
```